### PR TITLE
fix(wallet): preserve Blockfrost errors and accumulate balances as BigInt

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -224,6 +224,15 @@ async function callBlockfrost<R = any>(
     return callBlockfrost(mainnet, path, params, retryCount + 1);
   }
 
+  // 404 on an address/account endpoint means "never seen on-chain" — a genuine
+  // empty, NOT a failure. Return null so callers can treat it as empty without
+  // conflating it with a transient error. Transient errors must keep throwing
+  // (below) so they propagate and get retried, rather than silently becoming a
+  // zero balance that then poisons the 30s cache.
+  if (res.status === 404) {
+    return null as R;
+  }
+
   if (!res.ok) {
     const body = await res.text();
     console.error(`Sorbet: Blockfrost ${res.status} for ${path}:`, body);
@@ -306,9 +315,10 @@ async function handleRequest(request: any) {
           page: (request?.paginate?.page ?? 1).toString(),
         }
       );
-      const addresses = addrs?.map(({ address }: { address: string }) => {
-        return address;
-      });
+      const addresses =
+        addrs?.map(({ address }: { address: string }) => {
+          return address;
+        }) ?? [];
       blockfrostCache.usedAddresses[impersonatedAddress] = setCache(addresses);
       persistCacheToSession();
       return {
@@ -419,13 +429,18 @@ async function getUtxosForAddress(mainnet: boolean, address: string): Promise<an
   let page = 1;
 
   // Speculative parallel fetch: request PARALLEL_PAGES pages at once.
+  // NOTE: we deliberately do NOT swallow page errors. callBlockfrost returns
+  // null for a 404 (a genuine empty page, past the last page or an unused
+  // address); any other failure (429 after retries, 5xx, network) throws and
+  // must propagate so the caller can retry — silently coercing it to [] here
+  // would undercount or zero the balance and then cache that wrong result.
   while (true) {
     const pageNumbers = Array.from({ length: PARALLEL_PAGES }, (_, i) => page + i);
     const pageResults = await Promise.all(
       pageNumbers.map((p) =>
-        callBlockfrost(mainnet, `/api/v0/addresses/${address}/utxos`, { page: p.toString() }).catch(
-          () => []
-        )
+        callBlockfrost<any[] | null>(mainnet, `/api/v0/addresses/${address}/utxos`, {
+          page: p.toString(),
+        })
       )
     );
 
@@ -441,7 +456,7 @@ async function getUtxosForAddress(mainnet: boolean, address: string): Promise<an
     // If no pages returned data, or the last non-empty page was not full, we're done.
     if (lastNonEmpty === -1) break;
     const lastPage = pageResults[lastNonEmpty];
-    if (lastPage.length < BLOCKFROST_PAGE_SIZE) break;
+    if (!lastPage || lastPage.length < BLOCKFROST_PAGE_SIZE) break;
 
     page += PARALLEL_PAGES;
   }

--- a/src/utils/balance.ts
+++ b/src/utils/balance.ts
@@ -10,13 +10,16 @@ export function computeBalanceFromAmounts(addressInfos: { amount: Quantity[] }[]
 }
 
 export function foldAssets(allData: { ada: Quantity[]; assets: Quantity[] }[]) {
+  // Accumulate in BigInt: lovelace and native-token quantities are u64 values
+  // that routinely exceed Number.MAX_SAFE_INTEGER (2^53). Summing them as
+  // Number silently loses precision and, for a token near u64-max, rounds up
+  // past u64 — producing CBOR the Cardano deserializer rejects. We keep the
+  // results as decimal strings so the balance stays JSON-serializable across
+  // the extension message boundary.
   return allData.reduce((acc, { ada, assets }) => {
     acc.coin = (
-      Number(acc.coin ?? 0) +
-      ada.reduce((total, { quantity }) => {
-        total += Number(quantity);
-        return total;
-      }, 0)
+      BigInt(acc.coin ?? 0) +
+      ada.reduce((total, { quantity }) => total + BigInt(quantity), 0n)
     ).toString();
 
     if (assets) {
@@ -33,8 +36,9 @@ export function foldAssets(allData: { ada: Quantity[]; assets: Quantity[] }[]) {
         if (acc.multi_assets[policyId] === undefined) {
           acc.multi_assets[policyId] = {};
         }
-        acc.multi_assets[policyId][tokenName] =
-          Number(acc.multi_assets?.[policyId]?.[tokenName] ?? 0) + Number(quantity);
+        acc.multi_assets[policyId][tokenName] = (
+          BigInt(acc.multi_assets?.[policyId]?.[tokenName] ?? 0) + BigInt(quantity)
+        ).toString();
       });
     }
 

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -29,9 +29,12 @@ export interface MultiAssetOut {
   output_index: any;
   amount: MultiAssetAmount;
 }
-export interface MultiAssetAmount<C = number> {
+export interface MultiAssetAmount<C = string> {
   coin: C;
-  multi_assets?: { [policyId: string]: { [tokenName: string]: number } };
+  // Decimal strings: token quantities are u64 and can exceed Number's safe
+  // integer range, so they are accumulated and stored as strings (BigInt at
+  // the CBOR-encode boundary) to avoid precision loss / overflow.
+  multi_assets?: { [policyId: string]: { [tokenName: string]: string } };
 }
 
 export function utxosToHexArray(utxos: UTxOWithAssets[]) {
@@ -111,10 +114,9 @@ export function encodeUtxos(utxos: MultiAssetIn[]): MultiAssetOut[] {
       });
 
       const balance: MultiAssetAmount = {
-        coin: ada.reduce((total: number, { quantity }: Quantity) => {
-          total += Number(quantity);
-          return total;
-        }, 0),
+        coin: ada
+          .reduce((total: bigint, { quantity }: Quantity) => total + BigInt(quantity), 0n)
+          .toString(),
       };
 
       if (assets) {
@@ -126,8 +128,9 @@ export function encodeUtxos(utxos: MultiAssetIn[]): MultiAssetOut[] {
             if (balance.multi_assets[policyId] === undefined) {
               balance.multi_assets[policyId] = {};
             }
-            balance.multi_assets[policyId][tokenName] =
-              Number(balance.multi_assets?.[policyId]?.[tokenName] ?? 0) + Number(quantity);
+            balance.multi_assets[policyId][tokenName] = (
+              BigInt(balance.multi_assets?.[policyId]?.[tokenName] ?? 0) + BigInt(quantity)
+            ).toString();
           }
         });
       }


### PR DESCRIPTION
## Summary
- Treat Blockfrost `404` on address/account endpoints as a genuine empty result rather than an error, so unused addresses don't surface as failures.
- Stop swallowing real Blockfrost errors in `getUtxosForAddress`; transient failures (429 after retries, 5xx, network) now propagate so they can be retried instead of being silently coerced to `[]` and caching an undercounted balance.
- Accumulate multi-asset / lovelace quantities with `BigInt` and store as decimal strings — token amounts are u64 and routinely exceed `Number.MAX_SAFE_INTEGER`, which was producing rounding errors and CBOR the Cardano deserializer rejected.
- Update `MultiAssetAmount` to reflect the string-valued `multi_assets` shape and coalesce a possibly-undefined addresses list to `[]`.

## Testing
- Not run (not requested)
